### PR TITLE
Fix the missing <vector> error

### DIFF
--- a/jaroWinkler.cpp
+++ b/jaroWinkler.cpp
@@ -1,7 +1,7 @@
 #include "jaroWinkler.hpp"
 
 #include <algorithm>
-
+#include <vector>
 
 
 


### PR DESCRIPTION
Fix the build error by adding #include<vector>. Otherwise, it cannot build.